### PR TITLE
support arm64 binaries

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -27,8 +27,10 @@ download_release() {
   proc=$(uname -m)
   if [ "$proc" = "x86_64" ]; then
     arch="amd64"
+  elif [ "$proc" = "arm64" ]; then
+    arch="arm64"
   else
-    fail "$TOOL_NAME only has built binaries for amd64."
+    fail "$TOOL_NAME only has built binaries for amd64 and arm64."
   fi
   url="$GH_REPO/releases/download/v${version}/${TOOL_NAME}-v${version}-${os}-${arch}"
 


### PR DESCRIPTION
Chamber now supports darwin/arm64 as of `2.10.8`, released yesterday. I attempted to make changes to `asdf-chamber` to get it to support arm64, but I didn't quite get it working. Would appreciate any feedback to get this finished, I'm not exactly sure how to debug this further:

```
➜  asdf-chamber git:(master) asdf plugin test chamber https://github.com/johnnyplaydrums/asdf-chamber.git 2.10.8
Updating chamber to master
Already on 'master'
Your branch is up to date with 'origin/master'.
* Downloading chamber release 2.10.8...
chamber 2.10.8 installation was successful!
zsh:1: command not found: 2.10.8
FAILED: /bin/zsh -c 2.10.8 failed with exit code 0
➜  asdf-chamber git:(master) chamber -v
zsh: command not found: chamber
➜  asdf-chamber git:(master)