### PR TITLE
remove arch check to allow arm64

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -27,8 +27,10 @@ download_release() {
   proc=$(uname -m)
   if [ "$proc" = "x86_64" ]; then
     arch="amd64"
+  elif [ "$proc" = "arm64" ]; then
+    arch="arm64"
   else
-    fail "$TOOL_NAME only has built binaries for amd64."
+    fail "Unsupported architecture: $proc"
   fi
   url="$GH_REPO/releases/download/v${version}/${TOOL_NAME}-v${version}-${os}-${arch}"
 


### PR DESCRIPTION
chamber's been releasing arm64 for about 10 months or so now, so this
check is no longer true.

My team is on M1 macOS machines now, so we need to be able to grab arm64
chambers.
